### PR TITLE
Add support to winsparkle 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Basic Example:
 
 ```python
 from pywinsparkle import pywinsparkle
-
+import os
 
 def no_update_found():
     """ when no update has been found, close the updater"""
@@ -74,7 +74,7 @@ def main():
 
     # register callbacks
     pywinsparkle.win_sparkle_set_did_find_update_callback(found_update)
-    pywinsparkle.win_sparkle_set_error_callback(callbacks.encountered_error)
+    pywinsparkle.win_sparkle_set_error_callback(encountered_error)
     pywinsparkle.win_sparkle_set_update_cancelled_callback(update_cancelled)
     pywinsparkle.win_sparkle_set_did_not_find_update_callback(no_update_found)
     pywinsparkle.win_sparkle_set_shutdown_request_callback(shutdown)
@@ -83,6 +83,11 @@ def main():
     update_url = "https://winsparkle.org/example/appcast.xml"
     pywinsparkle.win_sparkle_set_appcast_url(update_url)
     pywinsparkle.win_sparkle_set_app_details("VendorName", "TestApp1", "1.0.0")
+
+    if os.path.isfile('dsa_pub.pem'):
+        with open('dsa_pub.pem', 'r') as file:
+            pub_key = file.read()
+        pywinsparkle.win_sparkle_set_dsa_pub_pem(pub_key)
 
     # initialize
     pywinsparkle.win_sparkle_init()

--- a/pywinsparkle/pywinsparkle.py
+++ b/pywinsparkle/pywinsparkle.py
@@ -196,7 +196,7 @@ def win_sparkle_set_automatic_check_for_updates(update_state):
     dll.win_sparkle_set_automatic_check_for_updates.argtypes = [c_int64]
     dll.win_sparkle_set_automatic_check_for_updates(update_state)
 
-    return result
+    #return result
 
 def win_sparkle_set_update_check_interval(interval):
     """ Sets the automatic update interval.

--- a/pywinsparkle/pywinsparkle.py
+++ b/pywinsparkle/pywinsparkle.py
@@ -23,10 +23,10 @@ else:
     THIS_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
     DLL_FILE = os.path.join(THIS_DIRECTORY, LIB_FOLDER, "WinSparkle")
 
-
 # documentation and wheel creation is done on linux, if this is linux then
 # dont try and load the DLL.
 if os.name == "nt":
+    print(DLL_FILE)
     dll = cdll.LoadLibrary(DLL_FILE)
 else:
     dll = None
@@ -125,8 +125,10 @@ def win_sparkle_set_dsa_pub_pem(dsa_pub_pem):
 
     dll.win_sparkle_set_dsa_pub_pem.restype = c_int64
     dll.win_sparkle_set_dsa_pub_pem.argtypes = [c_char_p]
-    dll.win_sparkle_set_dsa_pub_pem(dsa_pub_pem.encode())
-    
+    result = dll.win_sparkle_set_dsa_pub_pem(dsa_pub_pem.encode())
+
+    return result
+
 def win_sparkle_set_app_build_version(build_number):
     """ Sets application build version number.
 
@@ -169,6 +171,19 @@ def win_sparkle_set_registry_path(registry_path):
     dll.win_sparkle_set_registry_path.argtypes = [c_wchar_p]
     dll.win_sparkle_set_registry_path(registry_path)
 
+def win_sparkle_get_automatic_check_for_updates():
+    """     Gets the automatic update checking state
+    @return  1 if updates are set to be checked automatically, 0 otherwise
+    @note Defaults to 0 when not yet configured (as happens on first start).
+    @since 0.4
+
+    """
+
+    dll.win_sparkle_get_automatic_check_for_updates.restype = c_int64
+    dll.win_sparkle_get_automatic_check_for_updates.argtypes = None
+    result = dll.win_sparkle_get_automatic_check_for_updates()
+
+    return result
 
 def win_sparkle_set_automatic_check_for_updates(update_state):
     """ Sets whether updates are checked automatically or only through a manual call.
@@ -181,6 +196,7 @@ def win_sparkle_set_automatic_check_for_updates(update_state):
     dll.win_sparkle_set_automatic_check_for_updates.argtypes = [c_int64]
     dll.win_sparkle_set_automatic_check_for_updates(update_state)
 
+    return result
 
 def win_sparkle_set_update_check_interval(interval):
     """ Sets the automatic update interval.

--- a/pywinsparkle/pywinsparkle.py
+++ b/pywinsparkle/pywinsparkle.py
@@ -111,7 +111,22 @@ def win_sparkle_set_app_details(company_name, app_name, app_version):
     dll.win_sparkle_set_app_details.argtypes = [c_wchar_p, c_wchar_p, c_wchar_p]
     dll.win_sparkle_set_app_details(company_name, app_name, app_version)
 
+def win_sparkle_set_dsa_pub_pem(dsa_pub_pem):
+    """     Sets DSA public key.
+    Only PEM format is supported.
+    Public key will be used to verify DSA signature of the update file.
+    PEM data will be set only if it contains valid DSA public key.
+    If this function isn't called by the app, public key is obtained from
+    Windows resource named "DSAPub" of type "DSAPEM".
+    @param dsa_pub_pem  DSA public key in PEM format.
+    @return  1 if valid DSA public key provided, 0 otherwise.
+    @since 0.6.0
+    """
 
+    dll.win_sparkle_set_dsa_pub_pem.restype = c_int64
+    dll.win_sparkle_set_dsa_pub_pem.argtypes = [c_char_p]
+    dll.win_sparkle_set_dsa_pub_pem(dsa_pub_pem.encode())
+    
 def win_sparkle_set_app_build_version(build_number):
     """ Sets application build version number.
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, Distribution
-#from pypandoc import convert_file
+from pypandoc import convert_file
 
 class BinaryDistribution(Distribution):
     def has_ext_modules(foo):
@@ -7,12 +7,12 @@ class BinaryDistribution(Distribution):
 
 
 #: Converts the Markdown README in the RST format that PyPi expects.
-#long_description = convert_file('README.md', 'rst')
+long_description = convert_file('README.md', 'rst')
 
 
 setup(name='pywinsparkle',
       description='A python wrapper for the winsparkle project',
-      long_description='A python wrapper for the winsparkle project',
+      long_description=long_description,
       version='1.5.0',
       url='https://github.com/dyer234/pywinsparkle',
       author='Daniel Dyer',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, Distribution
-from pypandoc import convert_file
+#from pypandoc import convert_file
 
 class BinaryDistribution(Distribution):
     def has_ext_modules(foo):
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 
 #: Converts the Markdown README in the RST format that PyPi expects.
-long_description = convert_file('README.md', 'rst')
+#long_description = convert_file('README.md', 'rst')
 
 
 setup(name='pywinsparkle',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class BinaryDistribution(Distribution):
 
 setup(name='pywinsparkle',
       description='A python wrapper for the winsparkle project',
-      long_description=long_description,
+      long_description='A python wrapper for the winsparkle project',
       version='1.5.0',
       url='https://github.com/dyer234/pywinsparkle',
       author='Daniel Dyer',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, Distribution
-from pypandoc import convert_file
+#from pypandoc import convert_file
 
 class BinaryDistribution(Distribution):
     def has_ext_modules(foo):
@@ -7,12 +7,12 @@ class BinaryDistribution(Distribution):
 
 
 #: Converts the Markdown README in the RST format that PyPi expects.
-long_description = convert_file('README.md', 'rst')
+#long_description = convert_file('README.md', 'rst')
 
 
 setup(name='pywinsparkle',
       description='A python wrapper for the winsparkle project',
-      long_description=long_description,
+      long_description='A python wrapper for the winsparkle project',
       version='1.5.0',
       url='https://github.com/dyer234/pywinsparkle',
       author='Daniel Dyer',


### PR DESCRIPTION
Adding two new methods:
win_sparkle_set_dsa_pub_pem -> to set the dsa_pub.pem file, to check if the installer has been signed.
win_sparkle_get_automatic_check_for_updates -> this method returns 0 if the api will look not look for updates or 1 if will look for updates.

The readme example has also been updated check if a dsa_pub.pem file is available, if yes, it will load the file and call set_dsa_pub_pem.